### PR TITLE
无法使用自定义按钮，关闭modal #42

### DIFF
--- a/src/ModalTrigger.js
+++ b/src/ModalTrigger.js
@@ -90,8 +90,8 @@ var ModalTrigger = React.createClass({
         modalWidth: this.state.modalWidth,
         modalHeight: this.state.modalHeight,
         title: this.props.modal.props.title || this.props.title,
-        onConfirm: createChainedFunction(this.close, this.props.onConfirm),
-        onCancel: createChainedFunction(this.close, this.props.onCancel)
+        onConfirm: createChainedFunction(this.props.onConfirm, this.close),
+        onCancel: createChainedFunction(this.props.onCancel, this.close)
       }
     );
   },

--- a/src/utils/createChainedFunction.js
+++ b/src/utils/createChainedFunction.js
@@ -33,8 +33,7 @@ function createChainedFunction(one, two) {
   }
 
   return function chainedFunction() {
-    one.apply(this, arguments);
-    two.apply(this, arguments);
+    one.apply(this, arguments) === false || two.apply(this, arguments);
   };
 }
 


### PR DESCRIPTION
为了解决 [无法使用自定义按钮，关闭modal #42](https://github.com/amazeui/amazeui-react/issues/42)