### PR TITLE
Fix Unknown Prop Warning

### DIFF
--- a/docs/button/14-loading-button.js
+++ b/docs/button/14-loading-button.js
@@ -26,10 +26,13 @@ var LoadingButton = React.createClass({
 
   render: function() {
     var isLoading = this.state.isLoading;
+    var restProps = Object.assign({}, this.props);
+    delete restProps.clickHandler;
+    delete restProps.loadingText;
 
     return (
       <Button
-        {...this.props}
+        {...restProps}
         disabled={isLoading}
         onClick={!isLoading ? this.handleClick : null}>
         {isLoading ? this.props.loadingText : this.props.children}

--- a/docs/button/15-check-button.js
+++ b/docs/button/15-check-button.js
@@ -3,12 +3,12 @@ var buttonsInstance = (
     复选
     <br/>
     <ButtonCheck>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="checkbox" name="doc-js-btn" value="苹果"/> 苹果</Button>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="checkbox" name="doc-js-btn" value="橘子"/> 橘子
       </Button>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="checkbox" name="doc-js-btn" value="香蕉"/> 香蕉
       </Button>
     </ButtonCheck>
@@ -16,16 +16,16 @@ var buttonsInstance = (
     单选
     <br/>
     <ButtonCheck>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="radio" name="options" value="选项 1" id="option1"/> 选项 1
       </Button>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="radio" name="options" value="选项 2" id="option2"/> 选项 2
       </Button>
-      <Button amStyle="primary" componentTag="label">
+      <Button amStyle="primary">
         <input type="radio" name="options" value="选项 3" id="option3"/> 选项 3
       </Button>
-      <Button amStyle="primary" componentTag="label" disabled>
+      <Button amStyle="primary" disabled>
         <input type="radio" name="options" value="选项 4" id="option4"/> 选项 4
       </Button>
     </ButtonCheck>

--- a/docs/smooth-scroll/03-scroll-to.js
+++ b/docs/smooth-scroll/03-scroll-to.js
@@ -10,9 +10,13 @@ var ScrollTo = React.createClass({
   },
 
   render: function() {
+    var restProps = Object.assign({}, this.props);
+    delete restProps.position;
+    delete restProps.speed;
+
     return (
       <Button
-        {...this.props}
+        {...restProps}
         onClick={this.handleClick}>
         {this.props.children}
       </Button>

--- a/docs/table/05-json-table.js
+++ b/docs/table/05-json-table.js
@@ -19,8 +19,11 @@ var EventRow = React.createClass({
 
 var EventsTable = React.createClass({
   render: function() {
+    var restProps = Object.assign({}, this.props);
+    delete restProps.events;
+
     return (
-      <Table {...this.props}>
+      <Table {...restProps}>
         <thead>
           <tr>
             <th>名称</th>

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var CollapseMixin = require('./mixins/CollapseMixin');
 
@@ -10,6 +11,7 @@ var Accordion = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     theme: React.PropTypes.oneOf(['default', 'basic', 'gapped']),
     data: React.PropTypes.array,
     activeKey: React.PropTypes.any,
@@ -43,12 +45,13 @@ var Accordion = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass(this.props.theme)] = true;
 
     return (
       <section
-        {...this.props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(classSet, this.props.className)}
       >

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Alert = React.createClass({
@@ -34,6 +35,7 @@ var Alert = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
     var isCloseable = !!this.props.onClose;
 
     if (this.props.amStyle) {
@@ -44,7 +46,7 @@ var Alert = React.createClass({
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {isCloseable ? this.renderCloseBtn() : null}

--- a/src/Article.js
+++ b/src/Article.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Article = React.createClass({
@@ -22,10 +23,11 @@ var Article = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <article
-        {...this.props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
       >
         <header className={this.prefixClass('hd')}>
@@ -69,6 +71,7 @@ Article.Child = React.createClass({
 
   render: function() {
     var role = this.props.role;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
     var Component;
     var classes = classNames(
       this.props.className,
@@ -89,12 +92,12 @@ Article.Child = React.createClass({
 
     return role === 'divider' ? (
       <hr
-        {...this.props}
+        {...restProps}
         className={classes}
       />
     ) : (
       <Component
-        {...this.props}
+        {...restProps}
         className={classes}
       >
         {this.props.children}

--- a/src/AvgGrid.js
+++ b/src/AvgGrid.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var AvgGrid = React.createClass({
@@ -27,6 +28,7 @@ var AvgGrid = React.createClass({
     var classSet = {};
     var prefixClass = this.prefixClass;
     var props = this.props;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     ['sm', 'md', 'lg'].forEach(function(size) {
       if (props[size]) {
@@ -36,7 +38,7 @@ var AvgGrid = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Badge = React.createClass({
@@ -11,7 +12,9 @@ var Badge = React.createClass({
     component: React.PropTypes.node,
     href: React.PropTypes.string,
     round: React.PropTypes.bool,
-    radius: React.PropTypes.bool
+    radius: React.PropTypes.bool,
+    amStyle: React.PropTypes.string,
+    classPrefix: React.PropTypes.string
   },
 
   getDefaultProps: function () {
@@ -24,10 +27,11 @@ var Badge = React.createClass({
   renderAnchor: function (classSet) {
     var Component = this.props.component || 'a';
     var href = this.props.href || '#';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         href={href}
         className={classNames(classSet, this.props.className)}
         role="badge"
@@ -41,6 +45,7 @@ var Badge = React.createClass({
     var classSet = this.getClassSet();
     var Component = this.props.component;
     var renderAnchor = this.props.href;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     if (renderAnchor) {
       return this.renderAnchor(classSet);
@@ -48,7 +53,7 @@ var Badge = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
       >
         {this.props.children}

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -3,12 +3,14 @@
 var React = require('react');
 var classNames = require('classnames');
 var assign = require('object-assign');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Breadcrumb = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     slash: React.PropTypes.bool,
     component: React.PropTypes.node.isRequired
   },
@@ -23,12 +25,13 @@ var Breadcrumb = React.createClass({
   render: function() {
     var classes = this.getClassSet();
     var Component = this.props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classes[this.prefixClass('slash')] = this.props.slash;
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {this.props.children}
@@ -59,10 +62,11 @@ Breadcrumb.Item = React.createClass({
   renderAnchor: function(classes) {
     var Component = this.props.component;
     var linkComponent = this.props.linkComponent || 'a';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classes}
       >
         {
@@ -83,6 +87,7 @@ Breadcrumb.Item = React.createClass({
   render: function() {
     var classes = classNames(this.props.className);
     var Component = this.props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     if (this.props.href || this.props.linkComponent) {
       return this.renderAnchor(classes);
@@ -90,7 +95,7 @@ Breadcrumb.Item = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classes}
       >
         {this.props.children}

--- a/src/Button.js
+++ b/src/Button.js
@@ -17,7 +17,10 @@ var Button = React.createClass({
     round: React.PropTypes.bool,
     component: React.PropTypes.node,
     href: React.PropTypes.string,
-    target: React.PropTypes.string
+    target: React.PropTypes.string,
+    type: React.PropTypes.string,
+    amSize: React.PropTypes.string,
+    amStyle: React.PropTypes.string
   },
 
   getDefaultProps: function() {
@@ -31,11 +34,11 @@ var Button = React.createClass({
   renderAnchor: function(classSet) {
     var Component = this.props.component || 'a';
     var href = this.props.href || '#';
-    var props = omit(this.props, 'type');
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...props}
+        {...restProps}
         href={href}
         className={classNames(this.props.className, classSet)}
         role="button"
@@ -47,10 +50,11 @@ var Button = React.createClass({
 
   renderButton: function(classSet) {
     var Component = this.props.component || 'button';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/ButtonCheck.js
+++ b/src/ButtonCheck.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var omit = require('object.omit');
 var CSSCore = require('./utils/CSSCore');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var ButtonGroup = require('./ButtonGroup');
@@ -51,9 +52,11 @@ var ButtonCheck = React.createClass({
   },
 
   render: function() {
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
+
     return (
       <ButtonGroup
-        {...this.props}
+        {...restProps}
         onClick={this.handleClick}
         className={this.setClassNamespace('btn-group-check')}
       >

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var ButtonGroup = React.createClass({
@@ -21,13 +22,14 @@ var ButtonGroup = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass('stacked')] = this.props.stacked;
     classSet[this.prefixClass('justify')] = this.props.justify;
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var ButtonToolbar = React.createClass({
@@ -19,10 +20,11 @@ var ButtonToolbar = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/Close.js
+++ b/src/Close.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var Icon = require('./Icon');
 
@@ -13,7 +14,8 @@ var Close = React.createClass({
     component: React.PropTypes.node,
     spin: React.PropTypes.bool,
     alt: React.PropTypes.bool,
-    icon: React.PropTypes.bool
+    icon: React.PropTypes.bool,
+    type: React.PropTypes.string
   },
 
   getDefaultProps: function() {
@@ -27,6 +29,7 @@ var Close = React.createClass({
     var Component = this.props.component || 'button';
     var classSet = this.getClassSet();
     var props = this.props;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // transfer type
     if (Component !== 'button') {
@@ -39,7 +42,7 @@ var Close = React.createClass({
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
         role="close"
       >

--- a/src/Code.js
+++ b/src/Code.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Code = React.createClass({
@@ -27,6 +28,7 @@ var Code = React.createClass({
     var langClassName = this.props.language &&
       ('language-' + this.props.language);
     var children = this.props.children;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     if (this.props.escape) {
       children = this.escape(children);
@@ -38,7 +40,7 @@ var Code = React.createClass({
 
     return (
       <pre
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, langClassName)}
       >
         {children}

--- a/src/Col.js
+++ b/src/Col.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Col = React.createClass({
@@ -37,6 +38,7 @@ var Col = React.createClass({
     var classSet = {};
     var props = this.props;
     var prefixClass = this.prefixClass;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     ['sm', 'md', 'lg'].forEach(function(size) {
       var prop = size;
@@ -49,16 +51,19 @@ var Col = React.createClass({
       if (props[prop] >= 0) {
         classSet[prefixClass(size + '-offset-') + props[prop]] = true;
       }
+      restProps = omit(restProps, prop);
 
       prop = size + 'Push';
       if (props[prop] >= 0) {
         classSet[prefixClass(size + '-push-') + props[prop]] = true;
       }
+      restProps = omit(restProps, prop);
 
       prop = size + 'Pull';
       if (props[prop] >= 0) {
         classSet[prefixClass(size + '-pull-') + props[prop]] = true;
       }
+      restProps = omit(restProps, prop);
 
       // `xxResetOrder` prop
       // - smResetOrder
@@ -67,6 +72,7 @@ var Col = React.createClass({
       if (props[size + 'ResetOrder']) {
         classSet[prefixClass(size + '-reset-order')] = true;
       }
+      restProps = omit(restProps, size + 'ResetOrder');
 
       // `xxCentered` prop
       // - smCentered
@@ -75,6 +81,7 @@ var Col = React.createClass({
       if (props[size + 'Centered']) {
         classSet[prefixClass(size + '-centered')] = true;
       }
+      restProps = omit(restProps, size + 'Centered');
 
       // `xxUnCentered` prop
       // - smUnCentered
@@ -83,6 +90,7 @@ var Col = React.createClass({
       if (props[size + 'UnCentered']) {
         classSet[prefixClass(size + '-uncentered')] = true;
       }
+      restProps = omit(restProps, size + 'UnCentered');
     });
 
     // `end` prop - end column
@@ -90,7 +98,7 @@ var Col = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/Container.js
+++ b/src/Container.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Container = React.createClass({
@@ -22,10 +23,11 @@ var Container = React.createClass({
   render: function() {
     var Component = this.props.component;
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/DateTimePicker/DateTimeInput.js
+++ b/src/DateTimePicker/DateTimeInput.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var fecha = require('fecha');
+var omit = require('object.omit');
 var Events = require('../utils/Events');
 var isNodeInTree = require('../utils/isNodeInTree');
 var Input = require('../Input');
@@ -12,7 +13,18 @@ var DateTimeInput = React.createClass({
   propTypes: {
     format: React.PropTypes.string,
     dateTime: React.PropTypes.string,
-    onSelect: React.PropTypes.func
+    date: React.PropTypes.string,
+    onSelect: React.PropTypes.func,
+    showTimePicker: React.PropTypes.bool,
+    showDatePicker: React.PropTypes.bool,
+    amStyle: React.PropTypes.oneOf(['success', 'danger', 'warning']),
+    viewMode: React.PropTypes.string,
+    minViewMode: React.PropTypes.string,
+    daysOfWeekDisabled: React.PropTypes.array,
+    locale: React.PropTypes.string,
+    weekStart: React.PropTypes.number,
+    minDate: React.PropTypes.string,
+    maxDate: React.PropTypes.string
   },
 
   getDefaultProps: function() {
@@ -118,10 +130,12 @@ var DateTimeInput = React.createClass({
   },
 
   render: function() {
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
+
     return (
       <div>
         <Input
-          {...this.props}
+          {...restProps}
           type="text"
           value={this.state.value}
           onClick={this.handleClick}

--- a/src/DateTimePicker/DateTimePicker.js
+++ b/src/DateTimePicker/DateTimePicker.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var classNames = require('classnames');
 var fecha = require('fecha');
+var omit = require('object.omit');
 var ClassNameMixin = require('../mixins/ClassNameMixin');
 var Icon = require('../Icon');
 var DatePicker = require('./DatePicker');
@@ -12,6 +13,7 @@ var DateTimePicker = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     showTimePicker: React.PropTypes.bool,
     showDatePicker: React.PropTypes.bool,
     caretDisplayed: React.PropTypes.bool,
@@ -180,13 +182,14 @@ var DateTimePicker = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     this.props.amStyle &&
     (classSet[this.prefixClass(this.props.amStyle)] = true);
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
       >
         {this.renderCaret()}

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Divider = React.createClass({
@@ -21,10 +22,11 @@ var Divider = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <hr
-        {...this.props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       />

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -4,6 +4,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
 var assign = require('object-assign');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var constants = require('./constants');
 var Button = require('./Button');
@@ -155,7 +156,6 @@ var Dropdown = React.createClass({
 
     return (
       <Component
-        btnStyle={null}
         className={classNames(this.props.className, classSet)}
       >
         <Button
@@ -197,11 +197,13 @@ Dropdown.Item = React.createClass({
     header: React.PropTypes.bool,
     divider: React.PropTypes.bool,
     linkComponent: React.PropTypes.any,
-    linkProps: React.PropTypes.object
+    linkProps: React.PropTypes.object,
+    active: React.PropTypes.bool
   },
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
     var children = null;
 
     classSet[this.setClassNamespace('dropdown-header')] = this.props.header;
@@ -226,7 +228,7 @@ Dropdown.Item = React.createClass({
 
     return (
       <li
-        {...this.props}
+        {...restProps}
         title={null}
         href={null}
         className={classNames(this.props.className, classSet)}

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Footer = React.createClass({
@@ -31,10 +32,11 @@ var Footer = React.createClass({
   render: function() {
     var classSet = this.getClassSet();
     var MobileTag = this.props.mobileLink ? 'a' : 'span';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <footer
-        {...this.props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       >

--- a/src/Form.js
+++ b/src/Form.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Form = React.createClass({
@@ -21,13 +22,14 @@ var Form = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass('horizontal')] = this.props.horizontal;
     classSet[this.prefixClass('inline')] = this.props.inline;
 
     return (
       <form
-        {...this.props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
       >
         {this.props.children}

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -69,11 +69,11 @@ var Gallery = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
-    var props = omit(this.props, ['classPrefix', 'data', 'theme']);
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <AvgGrid
-        {...props}
+        {...restProps}
         sm={this.props.sm || 2}
         md={this.props.md || 3}
         lg={this.props.lg || 4}

--- a/src/GoTop.js
+++ b/src/GoTop.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var SmoothScrollMixin = require('./mixins/SmoothScrollMixin');
 var Events = require('./utils/Events');
@@ -76,13 +77,14 @@ var GoTop = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass(this.props.theme)] = true;
     classSet[this.setClassNamespace('active')] = !this.isAutoHide();
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(classSet, this.props.className)}
       >

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Grid = React.createClass({
@@ -25,6 +26,7 @@ var Grid = React.createClass({
     var Component = this.props.component;
     var classSet = this.getClassSet();
     var props = this.props;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // .am-g-fixed
     classSet[this.prefixClass('fixed')] = props.fixed;
@@ -34,7 +36,7 @@ var Grid = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/Header.js
+++ b/src/Header.js
@@ -87,13 +87,14 @@ var Header = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // am-header-fixed: fixed header
     classSet[this.prefixClass('fixed')] = this.props.fixed;
 
     return (
       <header
-        {...omit(this.props, ['data', 'title'])}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       >

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -2,13 +2,16 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Icon = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     amStyle: React.PropTypes.string,
+    amSize: React.PropTypes.string,
     fw: React.PropTypes.bool,
     spin: React.PropTypes.bool,
     button: React.PropTypes.bool,
@@ -31,6 +34,7 @@ var Icon = React.createClass({
     var Component = props.href ? 'a' : props.component;
     var prefixClass = this.prefixClass;
     var setClassNamespace = this.setClassNamespace;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // am-icon-[iconName]
     classes[prefixClass(props.icon)] = true;
@@ -50,7 +54,7 @@ var Icon = React.createClass({
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {this.props.children}

--- a/src/Image.js
+++ b/src/Image.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var constants = require('./constants');
 
@@ -23,6 +24,7 @@ var Image = React.createClass({
 
   render: function() {
     var classSet = {};
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[constants.CLASSES.radius] = this.props.radius;
     classSet[constants.CLASSES.round] = this.props.round;
@@ -32,7 +34,7 @@ var Image = React.createClass({
 
     return (
       <img
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       />
     );

--- a/src/Input.js
+++ b/src/Input.js
@@ -8,6 +8,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var FormGroup = require('./FormGroup');
 var Button = require('./Button');
@@ -92,6 +93,7 @@ var Input = React.createClass({
     var fieldClassName = this.isCheckboxOrRadio() || this.isFile() ? '' :
       this.setClassNamespace('form-field');
     var classSet = {};
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[constants.CLASSES.round] = this.props.round;
     classSet[constants.CLASSES.radius] = this.props.radius;
@@ -106,7 +108,7 @@ var Input = React.createClass({
       case 'select':
         input = (
           <select
-            {...this.props}
+            {...restProps}
             className={classes}
             ref="field"
             key="field"
@@ -118,7 +120,7 @@ var Input = React.createClass({
       case 'textarea':
         input = (
           <textarea
-            {...this.props}
+            {...restProps}
             className={classes}
             ref="field"
             key="field"
@@ -129,7 +131,7 @@ var Input = React.createClass({
       case 'reset':
         input = (
           <Button
-            {...this.props}
+            {...restProps}
             component="input"
             ref="field"
             key="field"
@@ -139,7 +141,7 @@ var Input = React.createClass({
       default:
         input = (
           <input
-            {...this.props}
+            {...restProps}
             className={classes}
             ref="field"
             key="field"

--- a/src/List.js
+++ b/src/List.js
@@ -2,12 +2,15 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var List = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
+    border: React.PropTypes.bool,
     bordered: React.PropTypes.bool,
     striped: React.PropTypes.bool,
     static: React.PropTypes.bool,
@@ -26,6 +29,7 @@ var List = React.createClass({
     var Component = this.props.component;
     var props = this.props;
     var prefixClass = this.prefixClass;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // am-list-border
     classes[prefixClass('border')] = props.border || props.bordered;
@@ -38,7 +42,7 @@ var List = React.createClass({
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classes, props.className)}
       >
         {props.children}

--- a/src/ListItem.js
+++ b/src/ListItem.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var classNames = require('classnames');
 var assign = require('object-assign');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var ListItem = React.createClass({
@@ -25,6 +26,7 @@ var ListItem = React.createClass({
   render: function() {
     var classes = {};
     var Component = this.props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // set .am-text-truncate
     classes['am-text-truncate'] = this.props.truncate;
@@ -36,7 +38,7 @@ var ListItem = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {this.props.children}
@@ -49,10 +51,11 @@ var ListItem = React.createClass({
     var Component = props.component;
     var truncate = props.truncate ? 'am-text-truncate' : '';
     var linkComponent = this.props.linkComponent || 'a';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {

--- a/src/ListNews.js
+++ b/src/ListNews.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var Button = require('./Button');
 var Col = require('./Col');
@@ -207,10 +208,11 @@ var ListNews = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       >

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -177,13 +177,13 @@ var Menu = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
-    var props = omit(this.props, 'data');
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
     var hideTopLevel = !this.state.expanded ?
       this.setClassNamespace('collapse') : null;
 
     return (
       <nav
-        {...props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       >

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var DimmerMixin = require('./mixins/DimmerMixin');
 var Events = require('./utils/Events');
@@ -233,6 +234,7 @@ var Modal = React.createClass({
       width: props.modalWidth,
       height: props.modalHeight,
     };
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass('active')] = this.state.transitioning;
 
@@ -242,7 +244,7 @@ var Modal = React.createClass({
 
     var modal = (
       <div
-        {...props}
+        {...restProps}
         style={style}
         ref="modal"
         title={null}

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -2,15 +2,18 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Nav = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     justify: React.PropTypes.bool,
     pills: React.PropTypes.bool,
     tabs: React.PropTypes.bool,
+    topbar: React.PropTypes.bool,
     component: React.PropTypes.node.isRequired
   },
 
@@ -24,6 +27,7 @@ var Nav = React.createClass({
   render: function() {
     var classes = this.getClassSet();
     var Component = this.props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // set classes
     classes[this.prefixClass('pills')] = this.props.pills || this.props.topbar;
@@ -35,7 +39,7 @@ var Nav = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {this.props.children}

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -10,6 +10,7 @@ var NavItem = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     active: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     header: React.PropTypes.bool,
@@ -31,6 +32,7 @@ var NavItem = React.createClass({
     var classes = this.getClassSet();
     var props = this.props;
     var Component = props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // del am-nav
     classes[this.setClassNamespace(props.classPrefix)] = false;
@@ -45,7 +47,7 @@ var NavItem = React.createClass({
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classes, props.className)}
       >
         {this.props.children}
@@ -57,6 +59,7 @@ var NavItem = React.createClass({
     var Component = this.props.component;
     var linkComponent = this.props.linkComponent || 'a';
     var style = {};
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     this.props.disabled && (style.pointerEvents = 'none');
 
@@ -69,7 +72,7 @@ var NavItem = React.createClass({
 
     return (
       <Component
-        {...omit(this.props, ['href', 'target', 'title', 'disabled'])}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -27,13 +27,12 @@ var Navbar = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
-    var props = omit(this.props, 'data');
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
-        cf
         className={classNames(this.props.className, classSet)}
       >
         <ul className={this.prefixClass('nav')}>

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -10,7 +10,8 @@ var ClassNameMixin = require('./mixins/ClassNameMixin');
 var Pagination = React.createClass({
   mixins: [ClassNameMixin],
 
-  PropTypes: {
+  propTypes: {
+    classPrefix: React.PropTypes.string,
     component: React.PropTypes.node.isRequired,
     centered: React.PropTypes.bool,
     right: React.PropTypes.bool,
@@ -91,6 +92,7 @@ var Pagination = React.createClass({
     var Component = props.component;
     var classSet = this.getClassSet();
     var notSelect = props.theme !== 'select';
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // .am-pagination-right
     classSet[this.prefixClass('right')] = props.right;
@@ -100,7 +102,7 @@ var Pagination = React.createClass({
 
     return props.data ? (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classSet, props.className)}
       >
         {notSelect && this.renderItem('first')}
@@ -111,7 +113,7 @@ var Pagination = React.createClass({
       </Component>
     ) : (
       <Component
-        {...props}
+        {...restProps}
         className={classNames(classSet, props.className)}
       >
         {this.props.children}
@@ -124,6 +126,7 @@ Pagination.Item = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     active: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     prev: React.PropTypes.bool,
@@ -147,6 +150,7 @@ Pagination.Item = React.createClass({
     var props = this.props;
     var linkComponent = this.props.linkComponent ||
           (this.props.href ? 'a' : null);
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // .am-pagination-prev
     classSet[this.prefixClass('prev')] = props.prev;
@@ -156,7 +160,7 @@ Pagination.Item = React.createClass({
 
     return (
       <Component
-        {...omit(this.props, ['href', 'title', 'target'])}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
       >
         {linkComponent ?

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var CollapseMixin = require('./mixins/CollapseMixin');
 
@@ -14,6 +15,7 @@ var Panel = React.createClass({
     header: React.PropTypes.node,
     footer: React.PropTypes.node,
     id: React.PropTypes.string,
+    classPrefix: React.PropTypes.string,
     amStyle: React.PropTypes.string,
     onSelect: React.PropTypes.func,
     eventKey: React.PropTypes.any
@@ -169,10 +171,11 @@ var Panel = React.createClass({
   render: function() {
     var classes = this.getClassSet();
     var collapsible = this.props.collapsible;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         id={collapsible ? null : this.props.id}
         className={classNames(classes, this.props.className)}
       >

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -2,12 +2,14 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var PanelGroup = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     amStyle: React.PropTypes.string,
     activeKey: React.PropTypes.any,
     defaultActiveKey: React.PropTypes.any,
@@ -71,10 +73,11 @@ var PanelGroup = React.createClass({
 
   render: function() {
     var classes = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         {React.Children.map(this.props.children, this.renderPanel)}

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Popover = React.createClass({
@@ -29,13 +30,14 @@ var Popover = React.createClass({
       top: this.props.positionTop,
       display: 'block'
     };
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.setClassNamespace('active')] = true;
     classSet[this.prefixClass(this.props.placement)] = true;
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         style={style}
         className={classNames(classSet, this.props.className)}
       >

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -2,12 +2,14 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Progress = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     now: React.PropTypes.number,
     label: React.PropTypes.string,
     active: React.PropTypes.bool,
@@ -57,6 +59,7 @@ var Progress = React.createClass({
 
   render: function() {
     var classes = this.getClassSet();
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // set class
     classes[this.prefixClass('striped')] = this.props.striped;
@@ -69,7 +72,7 @@ var Progress = React.createClass({
       if (!this.props.isChild) {
         return (
           <div
-            {...this.props}
+            {...restProps}
             className={classNames(classes, this.props.className)}
           >
             {this.renderProgressBar()}
@@ -83,7 +86,7 @@ var Progress = React.createClass({
     } else {
       return (
         <div
-          {...this.props}
+          {...restProps}
           className={classNames(classes, this.props.className)}
         >
           {React.Children.map(this.props.children, this.renderChildBar)}

--- a/src/ScrollSpyNav.js
+++ b/src/ScrollSpyNav.js
@@ -4,6 +4,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var cloneElement = React.cloneElement;
 var assign = require('object-assign');
+var omit = require('object.omit');
 var classNames = require('classnames');
 var SmoothScrollMixin = require('./mixins/SmoothScrollMixin');
 var isInViewport = require('./utils/isInViewport');
@@ -128,7 +129,7 @@ var ScrollSpyNav = React.createClass({
       child,
       assign(
         {},
-        this.props,
+        omit(this.props, Object.keys(this.constructor.propTypes)),
         child.props,
         {
           onClick: createChainedFunction(this.handleClick, child.props.onClick),

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var TransitionEvents = require('./utils/TransitionEvents');
 
@@ -12,6 +13,7 @@ var Slider = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     theme: React.PropTypes.oneOf(['default', 'a1', 'a2', 'a3', 'a4', 'a5',
       'b1', 'b2', 'b3', 'b4', 'c1', 'c2', 'c3', 'c4', 'd1', 'd2', 'd3']),
     directionNav: React.PropTypes.bool,   // prev/next icon
@@ -286,13 +288,14 @@ var Slider = React.createClass({
       position: 'relative',
       width: '100%'
     };
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // React version slider style
     classSet[this.prefixClass('slide')] = true;
 
     return (
       <div
-        {...this.props}
+        {...restProps}
         className={classNames(classSet, this.props.className)}
         onMouseOver={this.handleMouseOver}
         onMouseOut={this.handleMouseOut}

--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var assign = require('object-assign');
+var omit = require('object.omit');
 var classNames = require('classnames');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var Events = require('./utils/Events');
@@ -176,11 +177,12 @@ var Sticky = React.createClass({
     var child = React.Children.only(this.props.children);
     var animation = this.props.animation && this.state.sticked ?
       this.setClassNamespace('animation-' + this.props.animation) : null;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // transfer child's props to cloned element
     return (
       <div
-        {...this.props}
+        {...restProps}
         style={this.state.holderStyle}
         className={classNames(this.props.className,
         this.prefixClass('placeholder'))}

--- a/src/Table.js
+++ b/src/Table.js
@@ -2,6 +2,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 
 var Table = React.createClass({
@@ -26,6 +27,7 @@ var Table = React.createClass({
   render: function() {
     var classSet = this.getClassSet();
     var responsive = this.props.responsive;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.prefixClass('bordered')] = this.props.bordered;
     classSet[this.prefixClass('compact')] = this.props.compact;
@@ -38,7 +40,7 @@ var Table = React.createClass({
 
     var table = (
       <table
-        {...this.props}
+        {...restProps}
         className={classNames(this.props.className, classSet)}
       >
         {this.props.children}

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -11,6 +11,7 @@ var Tabs = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     theme: React.PropTypes.oneOf(['default', 'd2']),
     onSelect: React.PropTypes.func,
     animation: React.PropTypes.oneOf(['slide', 'fade']),
@@ -166,11 +167,11 @@ var Tabs = React.createClass({
 
   renderWrapper: function(children) {
     var classSet = this.getClassSet();
-    var props = omit(this.props, 'data');
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...props}
+        {...restProps}
         data-am-widget={this.props.theme ? this.props.classPrefix : null}
         className={classNames(classSet, this.props.className)}
       >
@@ -181,15 +182,19 @@ var Tabs = React.createClass({
 
   renderNavWrapper: function(children) {
     var TabsNav = this.props.theme ? 'ul' : Nav;
+    var props = {
+      key: "tabsNav",
+      tabs: true,
+      className: classNames(this.prefixClass('nav'), this.setClassNamespace('cf')),
+      justify: this.props.justify
+    };
+    if (TabsNav === 'ul') {
+      delete props.tabs;
+      delete props.justify;
+    }
 
     return (
-      <TabsNav
-        key="tabsNav"
-        tabs
-        className={classNames(this.prefixClass('nav'),
-          this.setClassNamespace('cf'))}
-        justify={this.props.justify}
-      >
+      <TabsNav {...props}>
         {children}
       </TabsNav>
     );

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -37,7 +37,7 @@ var Thumbnail = React.createClass({
     var classes = classNames(this.getClassSet(), this.props.className);
 
     if (this.props.standalone) {
-      return this.renderImg(classes, this.props);
+      return this.renderImg(classes, Object.keys(this.constructor.propTypes));
     }
 
     var Component = this.props.href ? 'a' : this.props.component;
@@ -47,12 +47,12 @@ var Thumbnail = React.createClass({
       width: this.props.width,
       height: this.props.height
     };
-    var props = omit(this.props, ['alt', 'src', 'width', 'height']);
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes), Object.keys(imgProps));
     var caption = this.props.caption;
 
     return (
       <Component
-        {...props}
+        {...restProps}
         className={classes}
       >
         {this.renderImg(null, imgProps)}
@@ -88,10 +88,11 @@ Thumbnail.Caption = React.createClass({
       this.props.className,
       this.setClassNamespace('thumbnail-caption')
     );
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classes}
       >
         {this.props.children}

--- a/src/Thumbnails.js
+++ b/src/Thumbnails.js
@@ -21,11 +21,11 @@ var Thumbnails = React.createClass({
 
   render: function() {
     var classes = classNames(this.getClassSet(), this.props.className);
-    var props = omit(this.props, 'classPrefix');
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <AvgGrid
-        {...props}
+        {...restProps}
         className={classes}
       >
         {React.Children.map(this.props.children, function(child, i) {

--- a/src/Titlebar.js
+++ b/src/Titlebar.js
@@ -26,11 +26,11 @@ var Titlebar = React.createClass({
 
   render: function() {
     var classSet = this.getClassSet();
-    var props = omit(this.props, ['classPrefix', 'nav', 'theme']);
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     return (
       <div
-        {...props}
+        {...restProps}
         data-am-widget={this.props.classPrefix}
         className={classNames(this.props.className, classSet)}
       >

--- a/src/Topbar.js
+++ b/src/Topbar.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var classNames = require('classnames');
 var assign = require('object-assign');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var createChainedFunction = require('./utils/createChainedFunction');
 var Icon = require('./Icon');
@@ -12,6 +13,7 @@ var Topbar = React.createClass({
   mixins: [ClassNameMixin],
 
   propTypes: {
+    classPrefix: React.PropTypes.string,
     component: React.PropTypes.node,
     brand: React.PropTypes.node,
     brandLink: React.PropTypes.string,
@@ -133,6 +135,7 @@ var Topbar = React.createClass({
   render: function() {
     var classes = this.getClassSet();
     var Component = this.props.component;
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     // set classes
     classes[this.prefixClass('inverse')] = this.props.inverse;
@@ -141,7 +144,7 @@ var Topbar = React.createClass({
 
     return (
       <Component
-        {...this.props}
+        {...restProps}
         className={classNames(classes, this.props.className)}
       >
         <div

--- a/src/UCheck.js
+++ b/src/UCheck.js
@@ -6,6 +6,7 @@
 
 var React = require('react');
 var classNames = require('classnames');
+var omit = require('object.omit');
 var ClassNameMixin = require('./mixins/ClassNameMixin');
 var Input = require('./Input');
 var Icon = require('./Icon');
@@ -31,6 +32,7 @@ var UCheck = React.createClass({
 
   render: function() {
     var classSet = {};
+    var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
 
     classSet[this.setClassNamespace(this.props.type)] = !this.props.inline;
     classSet[this.setClassNamespace(this.props.type + '-inline')] =
@@ -43,7 +45,7 @@ var UCheck = React.createClass({
     return (
       <label className={classNames(this.props.className, classSet)}>
         <Input
-          {...this.props}
+          {...restProps}
           ref="field"
           className={this.setClassNamespace('ucheck-checkbox')}
           standalone


### PR DESCRIPTION
React 15.2 introduced [Unknown Prop Warning](https://facebook.github.io/react/warnings/unknown-prop.html). The current master branch raises a lot of this warning. It's discussed in [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap/issues/1994) as well

Steps to reproduce:
1. checkout master branch
2. npm install react@15.2.0 && npm install
3. npm start
4. in browse console, you can see the warnings

This pull request fixes the issue in this style:

    render: function() {
      var restProps = omit(this.props, Object.keys(this.constructor.propTypes));
      return (
        <div {...restProps} />
      );
    }

All components fixed except for `Topbar` and `ScrollSpy`, which is a bit tricky.

Btw, another issue is found with react 15.2, for `Form` component:

> warning.js:44 Warning: Failed form propType: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`. Check the render method of `Button`.